### PR TITLE
3B-G10-W003-PR01. Text & Background Color Contrast Improvement 

### DIFF
--- a/src/app/(public)/create-admin/page.tsx
+++ b/src/app/(public)/create-admin/page.tsx
@@ -15,7 +15,11 @@ export default function CreateAdminHelpPage() {
         <div className="relative mx-auto max-w-3xl">
           <div className="mb-8 flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/60 bg-white/70 px-5 py-4 shadow-lg shadow-slate-200/50 backdrop-blur-xl">
             <Brand />
-            <Button asChild variant="ghost" className="rounded-2xl">
+            <Button
+              asChild
+              variant="ghost"
+              className="rounded-2xl font-semibold !text-slate-950 hover:bg-slate-100 hover:!text-slate-950"
+            >
               <Link href={ROUTES.landing}>Home</Link>
             </Button>
           </div>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -20,7 +20,11 @@ export default function RoleLoginPage({ searchParams }: Props) {
         <div className="relative mx-auto max-w-2xl">
           <div className="mb-8 flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 shadow-lg shadow-indigo-100/50 backdrop-blur-xl">
             <Brand />
-            <Button asChild variant="ghost" className="rounded-2xl text-slate-600">
+            <Button
+              asChild
+              variant="ghost"
+              className="rounded-2xl font-semibold !text-slate-950 hover:bg-slate-100 hover:!text-slate-950"
+            >
               <Link href={ROUTES.landing}>Home</Link>
             </Button>
           </div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(251,191,36,0.16),transparent_28%),radial-gradient(circle_at_bottom_left,rgba(56,189,248,0.12),transparent_24%)]" />
           <div className="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-8 sm:px-10 lg:px-14">
             <div>
-              <Brand />
+              <Brand onDarkBackground />
             </div>
 
             <div className="max-w-4xl py-10 sm:py-14">

--- a/src/components/admin/admin-dashboard-metrics.tsx
+++ b/src/components/admin/admin-dashboard-metrics.tsx
@@ -39,7 +39,7 @@ function KpiCard({
           <Icon className="h-5 w-5" />
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{title}</p>
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-950">{title}</p>
           <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900">{value ?? "—"}</p>
           <p className="mt-1 text-xs text-slate-500">{hint}</p>
         </div>

--- a/src/components/admin/admin-users-table.tsx
+++ b/src/components/admin/admin-users-table.tsx
@@ -106,7 +106,7 @@ export function AdminUsersTable() {
                 <col className="w-[14%]" />
                 <col className="w-[14%]" />
               </colgroup>
-              <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+              <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-950">
                 <tr>
                   <th className="px-4 py-3">User</th>
                   <th className="px-4 py-3">Role</th>

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -3,7 +3,15 @@ import { cn } from "@/lib/utils";
 
 const BRAND_MARK = `StyleH${"\u1D00"}${"\u026A"}R`;
 
-export function Brand({ inverted }: { inverted?: boolean }) {
+type BrandProps = {
+  /** Frosted mark + light subtitle for dark admin chrome */
+  inverted?: boolean;
+  /** Solid mark; light subtitle on dark hero sections */
+  onDarkBackground?: boolean;
+};
+
+export function Brand({ inverted, onDarkBackground }: BrandProps) {
+  const lightSubtitle = inverted || onDarkBackground;
   return (
     <div className="flex items-center gap-3">
       <div
@@ -16,7 +24,14 @@ export function Brand({ inverted }: { inverted?: boolean }) {
       </div>
       <div>
         <div className="brand-rainbow text-lg font-semibold tracking-tight">{BRAND_MARK}</div>
-        <div className={cn("text-xs", inverted ? "text-slate-400" : "text-slate-500")}>AI-assisted hairstyle recommendation system</div>
+        <div
+          className={cn(
+            "text-xs font-medium",
+            lightSubtitle ? "text-slate-200" : "text-slate-800",
+          )}
+        >
+          AI-assisted hairstyle recommendation system
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
-  Improves text contrast and readability for the StyleHair admin-facing UI: the brand tagline (“AI-assisted hairstyle recommendation system”), the **Home** link on public admin flows, KPI card titles on the admin dashboard, and column headers on the admin users table.
- Low-contrast labels were hard to read on light and dark backgrounds. However, stronger colors and weight improve accessibility without changing behavior.

## Changes
- Updated `Brand` subtitle styles and added `onDarkBackground` for the landing hero so the tagline stays readable on dark sections while keeping the existing icon treatment.
- Set **Home** controls on login and create-admin pages to bold, near-black text so they stand out on the frosted header bar.
- Set admin dashboard `KpiCard` titles to bolder, darker text (`Total users`, `Customers`, etc.).
- Set admin users table header row (`User`, `Role`, `Status`, `Joined`, `Action`) to darker, semibold text.

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.