### PR TITLE
3B-G10-W004-PR02. Implement Password Update Option

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,13 +1,24 @@
 import Link from "next/link";
 import { SectionHeader } from "@/components/shared/section-header";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { AdminChangePasswordForm } from "@/components/forms/admin-change-password-form";
 import { ROUTES } from "@/lib/routes";
 
 export default function AdminSettingsPage() {
   return (
     <div className="space-y-8">
       <SectionHeader title="Settings" description="Administrator accounts and deployment configuration." />
+
+      <Card className="rounded-2xl border-slate-200/80 bg-white/90 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Change your password</CardTitle>
+          <CardDescription>Updates the password for the account you are signed in with.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AdminChangePasswordForm />
+        </CardContent>
+      </Card>
 
       <Card className="rounded-2xl border-slate-200/80 bg-white/90 shadow-sm">
         <CardHeader>

--- a/src/app/api/admin/change-password/route.ts
+++ b/src/app/api/admin/change-password/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { hashPassword, verifyPassword } from "@/lib/password";
+import { prismaErrorToResponse } from "@/lib/prisma-errors";
+import { requireAdminSession } from "@/lib/require-session";
+import { validatePassword } from "@/lib/validators";
+
+export async function POST(request: Request) {
+  const { session, error } = await requireAdminSession(request);
+  if (error || !session) return error;
+
+  let body: { currentPassword?: string; newPassword?: string; confirmPassword?: string };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const currentPassword = body.currentPassword ?? "";
+  const newPassword = body.newPassword ?? "";
+  const confirmPassword = body.confirmPassword ?? "";
+
+  if (!currentPassword) {
+    return NextResponse.json({ error: "Current password is required." }, { status: 400 });
+  }
+  if (!newPassword) {
+    return NextResponse.json({ error: "New password is required." }, { status: 400 });
+  }
+  if (newPassword !== confirmPassword) {
+    return NextResponse.json({ error: "New password and confirmation do not match." }, { status: 400 });
+  }
+  if (!validatePassword(newPassword)) {
+    return NextResponse.json(
+      {
+        error: "New password must be at least 8 characters and include uppercase, lowercase, and a number.",
+      },
+      { status: 400 },
+    );
+  }
+  if (newPassword === currentPassword) {
+    return NextResponse.json({ error: "New password must be different from your current password." }, { status: 400 });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: session.sub },
+      select: { id: true, passwordHash: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: "Account not found." }, { status: 404 });
+    }
+
+    const valid = await verifyPassword(currentPassword, user.passwordHash);
+    if (!valid) {
+      return NextResponse.json({ error: "Current password is incorrect." }, { status: 401 });
+    }
+
+    const passwordHash = await hashPassword(newPassword);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash },
+    });
+
+    return NextResponse.json({ ok: true, message: "Your password has been updated." });
+  } catch (e) {
+    const pr = prismaErrorToResponse(e);
+    if (pr) return pr;
+    console.error(e);
+    return NextResponse.json({ error: "Could not update password." }, { status: 500 });
+  }
+}

--- a/src/components/forms/admin-change-password-form.tsx
+++ b/src/components/forms/admin-change-password-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { validatePassword } from "@/lib/validators";
+
+export function AdminChangePasswordForm() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setSuccess(null);
+    const nextErrors: Record<string, string> = {};
+    if (!currentPassword) nextErrors.currentPassword = "Enter your current password.";
+    if (!newPassword) nextErrors.newPassword = "Enter a new password.";
+    else if (!validatePassword(newPassword)) {
+      nextErrors.newPassword = "At least 8 characters with uppercase, lowercase, and a number.";
+    }
+    if (newPassword !== confirmPassword) nextErrors.confirmPassword = "Passwords do not match.";
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/admin/change-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          currentPassword,
+          newPassword,
+          confirmPassword,
+        }),
+      });
+      const data = (await res.json()) as { error?: string; message?: string };
+      if (!res.ok) {
+        setErrors({ form: data.error ?? "Could not update password." });
+        return;
+      }
+      setSuccess(data.message ?? "Your password has been updated.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch {
+      setErrors({ form: "Network error. Try again." });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      {success ? (
+        <div className="rounded-2xl border border-emerald-200 bg-emerald-50/90 px-4 py-3 text-sm text-emerald-900">{success}</div>
+      ) : null}
+      {errors.form ? <p className="text-sm text-rose-600">{errors.form}</p> : null}
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-change-current">Current password</Label>
+        <div className="relative">
+          <Input
+            id="admin-change-current"
+            type={showCurrent ? "text" : "password"}
+            className="h-12 rounded-2xl border-slate-200 bg-white/80 pl-3 pr-10 text-left shadow-inner shadow-slate-200/40 backdrop-blur"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            autoComplete="current-password"
+          />
+          <button
+            type="button"
+            className="absolute right-3 top-3 text-slate-400"
+            onClick={() => setShowCurrent((v) => !v)}
+            aria-label={showCurrent ? "Hide password" : "Show password"}
+          >
+            {showCurrent ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
+        </div>
+        {errors.currentPassword ? <p className="text-xs text-rose-500">{errors.currentPassword}</p> : null}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-change-new">New password</Label>
+        <div className="relative">
+          <Input
+            id="admin-change-new"
+            type={showNew ? "text" : "password"}
+            className="h-12 rounded-2xl border-slate-200 bg-white/80 pl-3 pr-10 text-left shadow-inner shadow-slate-200/40 backdrop-blur"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            autoComplete="new-password"
+          />
+          <button
+            type="button"
+            className="absolute right-3 top-3 text-slate-400"
+            onClick={() => setShowNew((v) => !v)}
+            aria-label={showNew ? "Hide password" : "Show password"}
+          >
+            {showNew ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
+        </div>
+        {errors.newPassword ? <p className="text-xs text-rose-500">{errors.newPassword}</p> : null}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="admin-change-confirm">Confirm new password</Label>
+        <Input
+          id="admin-change-confirm"
+          type={showNew ? "text" : "password"}
+          className="h-12 rounded-2xl border-slate-200 bg-white/80 pl-3 pr-3 text-left shadow-inner shadow-slate-200/40 backdrop-blur"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          autoComplete="new-password"
+        />
+        {errors.confirmPassword ? <p className="text-xs text-rose-500">{errors.confirmPassword}</p> : null}
+      </div>
+
+      <Button
+        type="button"
+        className="h-12 w-full rounded-2xl bg-slate-900 shadow-md shadow-slate-900/15 hover:bg-slate-800"
+        onClick={() => void handleSubmit()}
+        disabled={submitting}
+      >
+        {submitting ? "Updating…" : "Update password"}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a way for a signed-in administrator to update their own account password from **Settings**, including a secure API and a form with current password, new password, and confirmation.
- admins had no in-app option to change their password after sign-in; this closes that gap without changing existing sign-in or other unrelated flows.

## Changes

- Added `POST` handler at `src/app/api/admin/change-password/route.ts`: requires admin session, verifies current password with `verifyPassword`, validates new password with existing `validatePassword`, updates `passwordHash` for the session user.
- Added `src/components/forms/admin-change-password-form.tsx`: client form, validation, success/error messaging, calls the new API with credentials.
- Updated `src/app/admin/settings/page.tsx`: new “Change your password” card above the existing administrators section.

## Checklist

- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.