### PR TITLE
3B-G10-W002. Revision of User Name Handling

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -37,162 +37,178 @@ enum HairstyleCatalogPreference {
 }
 
 model User {
-  id                String               @id @default(cuid())
-  email             String               @unique
-  passwordHash      String               @map("password_hash")
-  role              UserRole
-  status            UserStatus           @default(ACTIVE)
-  createdAt         DateTime             @default(now()) @map("created_at")
-  updatedAt         DateTime             @updatedAt @map("updated_at")
+  id           String     @id @default(cuid())
+  email        String     @unique
+  passwordHash String     @map("password_hash")
+  role         UserRole
+  status       UserStatus @default(ACTIVE)
+  createdAt    DateTime   @default(now()) @map("created_at")
+  updatedAt    DateTime   @updatedAt @map("updated_at")
 
-  customerProfile   CustomerProfile?
-  faceUploads       FaceUpload[]
-  faceAnalyses      FaceAnalysis[]
-  recommendations   Recommendation[]
-  favorites         Favorite[]
-  reports           CustomerReport[]
-  satisfactions     Satisfaction[]
-  auditLogs         AuditLog[]           @relation("AuditActor")
-  pageViews         PageView[]
+  customerProfile      CustomerProfile?
+  faceUploads          FaceUpload[]
+  faceAnalyses         FaceAnalysis[]
+  recommendations      Recommendation[]
+  favorites            Favorite[]
+  reports              CustomerReport[]
+  satisfactions        Satisfaction[]
+  auditLogs            AuditLog[]            @relation("AuditActor")
+  pageViews            PageView[]
   hairstylePreviewLogs HairstylePreviewLog[]
+  adminProfile         AdminProfile?
 
   @@map("users")
 }
 
-model CustomerProfile {
-  id                String        @id @default(cuid())
-  userId            String        @unique @map("user_id")
-  firstName         String        @map("first_name")
-  lastName          String        @map("last_name")
-  phone             String?
-  birthDate         DateTime?     @map("birth_date")
-  gender            GenderOption?
-  preferredStyle    String?       @map("preferred_style")
-  hairType          String?       @map("hair_type")
-  notes             String?
-  hairstyleCatalogPreference HairstyleCatalogPreference @default(ALL) @map("hairstyle_catalog_preference")
-  createdAt         DateTime      @default(now()) @map("created_at")
-  updatedAt         DateTime      @updatedAt @map("updated_at")
+model AdminProfile {
+  id         String   @id @default(cuid())
+  userId     String   @unique @map("user_id")
+  firstName  String   @map("first_name")
+  middleName String   @map("middle_name")
+  lastName   String   @map("last_name")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
 
-  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("admin_profiles")
+}
+
+model CustomerProfile {
+  id                         String                     @id @default(cuid())
+  userId                     String                     @unique @map("user_id")
+  firstName                  String                     @map("first_name")
+  lastName                   String                     @map("last_name")
+  phone                      String?
+  birthDate                  DateTime?                  @map("birth_date")
+  gender                     GenderOption?
+  preferredStyle             String?                    @map("preferred_style")
+  hairType                   String?                    @map("hair_type")
+  notes                      String?
+  hairstyleCatalogPreference HairstyleCatalogPreference @default(ALL) @map("hairstyle_catalog_preference")
+  createdAt                  DateTime                   @default(now()) @map("created_at")
+  updatedAt                  DateTime                   @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("customer_profiles")
 }
 
 model FaceUpload {
-  id                String        @id @default(cuid())
-  userId            String        @map("user_id")
-  imageUrl          String        @map("image_url")
-  publicId          String?       @map("public_id")
-  uploadType        UploadType    @map("upload_type")
-  fileName          String?       @map("file_name")
-  fileSize          Int?          @map("file_size")
-  mimeType          String?       @map("mime_type")
-  createdAt         DateTime      @default(now()) @map("created_at")
+  id         String     @id @default(cuid())
+  userId     String     @map("user_id")
+  imageUrl   String     @map("image_url")
+  publicId   String?    @map("public_id")
+  uploadType UploadType @map("upload_type")
+  fileName   String?    @map("file_name")
+  fileSize   Int?       @map("file_size")
+  mimeType   String?    @map("mime_type")
+  createdAt  DateTime   @default(now()) @map("created_at")
 
-  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  analysis          FaceAnalysis?
+  user     User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  analysis FaceAnalysis?
 
   @@map("face_uploads")
 }
 
 model FaceAnalysis {
-  id                String          @id @default(cuid())
-  userId            String          @map("user_id")
-  faceUploadId      String          @unique @map("face_upload_id")
-  faceShape         String?         @map("face_shape")
-  jawlineType       String?         @map("jawline_type")
-  foreheadType      String?         @map("forehead_type")
-  cheekboneType     String?         @map("cheekbone_type")
-  confidenceScore   Float?          @map("confidence_score")
-  rawResultJson     Json?           @map("raw_result_json")
-  createdAt         DateTime        @default(now()) @map("created_at")
+  id              String   @id @default(cuid())
+  userId          String   @map("user_id")
+  faceUploadId    String   @unique @map("face_upload_id")
+  faceShape       String?  @map("face_shape")
+  jawlineType     String?  @map("jawline_type")
+  foreheadType    String?  @map("forehead_type")
+  cheekboneType   String?  @map("cheekbone_type")
+  confidenceScore Float?   @map("confidence_score")
+  rawResultJson   Json?    @map("raw_result_json")
+  createdAt       DateTime @default(now()) @map("created_at")
 
-  user              User            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  faceUpload        FaceUpload      @relation(fields: [faceUploadId], references: [id], onDelete: Cascade)
-  recommendation    Recommendation?
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  faceUpload     FaceUpload      @relation(fields: [faceUploadId], references: [id], onDelete: Cascade)
+  recommendation Recommendation?
 
   @@map("face_analyses")
 }
 
 model Recommendation {
-  id               String   @id @default(cuid())
-  userId           String   @map("user_id")
-  faceAnalysisId   String   @unique @map("face_analysis_id")
-  createdAt        DateTime @default(now()) @map("created_at")
+  id             String   @id @default(cuid())
+  userId         String   @map("user_id")
+  faceAnalysisId String   @unique @map("face_analysis_id")
+  createdAt      DateTime @default(now()) @map("created_at")
 
-  user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  faceAnalysis     FaceAnalysis  @relation(fields: [faceAnalysisId], references: [id], onDelete: Cascade)
-  items            RecommendationItem[]
+  user         User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  faceAnalysis FaceAnalysis         @relation(fields: [faceAnalysisId], references: [id], onDelete: Cascade)
+  items        RecommendationItem[]
 
   @@map("recommendations")
 }
 
 model Hairstyle {
-  id                String                @id @default(cuid())
-  name              String
-  description       String?
-  category          String?
-  maintenanceLevel  String?               @map("maintenance_level")
-  sampleImageUrl    String?               @map("sample_image_url")
-  suitableFaceShapes Json?                @map("suitable_face_shapes")
-  genderTag         String?               @map("gender_tag")
-  isActive          Boolean               @default(true) @map("is_active")
-  createdAt         DateTime              @default(now()) @map("created_at")
-  updatedAt         DateTime              @updatedAt @map("updated_at")
+  id                 String   @id @default(cuid())
+  name               String
+  description        String?
+  category           String?
+  maintenanceLevel   String?  @map("maintenance_level")
+  sampleImageUrl     String?  @map("sample_image_url")
+  suitableFaceShapes Json?    @map("suitable_face_shapes")
+  genderTag          String?  @map("gender_tag")
+  isActive           Boolean  @default(true) @map("is_active")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
 
   recommendationItems RecommendationItem[]
-  favorites         Favorite[]
+  favorites           Favorite[]
 
   @@map("hairstyles")
 }
-model RecommendationItem {
-  id                String          @id @default(cuid())
-  recommendationId  String          @map("recommendation_id")
-  hairstyleId       String          @map("hairstyle_id")
-  rank              Int
-  score             Float?
-  reason            String?
-  previewImageUrl   String?         @map("preview_image_url")
-  createdAt         DateTime        @default(now()) @map("created_at")
 
-  recommendation    Recommendation  @relation(fields: [recommendationId], references: [id], onDelete: Cascade)
-  hairstyle         Hairstyle       @relation(fields: [hairstyleId], references: [id], onDelete: Restrict)
+model RecommendationItem {
+  id               String   @id @default(cuid())
+  recommendationId String   @map("recommendation_id")
+  hairstyleId      String   @map("hairstyle_id")
+  rank             Int
+  score            Float?
+  reason           String?
+  previewImageUrl  String?  @map("preview_image_url")
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  recommendation Recommendation @relation(fields: [recommendationId], references: [id], onDelete: Cascade)
+  hairstyle      Hairstyle      @relation(fields: [hairstyleId], references: [id], onDelete: Restrict)
 
   @@map("recommendation_items")
 }
 
 model Favorite {
-  id                String      @id @default(cuid())
-  userId            String      @map("user_id")
-  hairstyleId       String      @map("hairstyle_id")
-  createdAt         DateTime    @default(now()) @map("created_at")
+  id          String   @id @default(cuid())
+  userId      String   @map("user_id")
+  hairstyleId String   @map("hairstyle_id")
+  createdAt   DateTime @default(now()) @map("created_at")
 
-  user              User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  hairstyle         Hairstyle   @relation(fields: [hairstyleId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  hairstyle Hairstyle @relation(fields: [hairstyleId], references: [id], onDelete: Cascade)
 
   @@unique([userId, hairstyleId])
   @@map("favorites")
 }
 
 model Satisfaction {
-  id                String      @id @default(cuid())
-  userId            String      @map("user_id")
-  rating            Int
-  createdAt         DateTime    @default(now()) @map("created_at")
+  id        String   @id @default(cuid())
+  userId    String   @map("user_id")
+  rating    Int
+  createdAt DateTime @default(now()) @map("created_at")
 
-  user              User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("satisfactions")
 }
 
 model CustomerReport {
-  id                String      @id @default(cuid())
-  userId            String      @map("user_id")
-  message           String
-  createdAt         DateTime    @default(now()) @map("created_at")
+  id        String   @id @default(cuid())
+  userId    String   @map("user_id")
+  message   String
+  createdAt DateTime @default(now()) @map("created_at")
 
-  user              User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("customer_reports")
 }
@@ -203,7 +219,7 @@ model PageView {
   userId    String?  @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
 
-  user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([path])
   @@index([createdAt])
@@ -211,26 +227,28 @@ model PageView {
 }
 
 model AuditLog {
-  id                String      @id @default(cuid())
-  actorUserId       String      @map("actor_user_id")
-  action            String
-  targetType        String?     @map("target_type")
-  targetId          String?     @map("target_id")
-  description       String?
-  createdAt         DateTime    @default(now()) @map("created_at")
+  id          String   @id @default(cuid())
+  actorUserId String   @map("actor_user_id")
+  action      String
+  targetType  String?  @map("target_type")
+  targetId    String?  @map("target_id")
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
 
-  actor             User        @relation("AuditActor", fields: [actorUserId], references: [id], onDelete: Cascade)
+  actor User @relation("AuditActor", fields: [actorUserId], references: [id], onDelete: Cascade)
 
   @@map("audit_logs")
 }
 
-/** One row per successful AI hairstyle preview (for quota / cooldown). */
+/**
+ * One row per successful AI hairstyle preview (for quota / cooldown).
+ */
 model HairstylePreviewLog {
   id        String   @id @default(cuid())
   userId    String   @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
 
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
   @@map("hairstyle_preview_logs")

--- a/src/app/api/admin/register-admin/route.ts
+++ b/src/app/api/admin/register-admin/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/db";
 import { hashPassword } from "@/lib/password";
 import { prismaErrorToResponse } from "@/lib/prisma-errors";
 import { requireAdminSession } from "@/lib/require-session";
-import { validateEmail, validatePassword } from "@/lib/validators";
+import { validateEmail, validateLettersOnlyName, validatePassword } from "@/lib/validators";
 
 function isStylehairAdminEmail(email: string) {
   return /^[^\s@]+@stylehair\.com$/i.test(email);
@@ -14,17 +14,43 @@ export async function POST(request: Request) {
   const { error } = await requireAdminSession(request);
   if (error) return error;
 
-  let body: { email?: string; password?: string; confirmPassword?: string };
+  let body: {
+    firstName?: string;
+    middleName?: string;
+    lastName?: string;
+    email?: string;
+    password?: string;
+    confirmPassword?: string;
+  };
   try {
-    body = (await request.json()) as { email?: string; password?: string; confirmPassword?: string };
+    body = (await request.json()) as {
+      firstName?: string;
+      middleName?: string;
+      lastName?: string;
+      email?: string;
+      password?: string;
+      confirmPassword?: string;
+    };
   } catch {
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
   }
 
+  const firstName = body.firstName?.trim() ?? "";
+  const middleName = body.middleName?.trim() ?? "";
+  const lastName = body.lastName?.trim() ?? "";
   const email = body.email?.trim().toLowerCase() ?? "";
   const password = body.password ?? "";
   const confirmPassword = body.confirmPassword ?? "";
 
+  if (!validateLettersOnlyName(firstName)) {
+    return NextResponse.json({ error: "First name must contain letters only." }, { status: 400 });
+  }
+  if (!validateLettersOnlyName(middleName)) {
+    return NextResponse.json({ error: "Middle name must contain letters only." }, { status: 400 });
+  }
+  if (!validateLettersOnlyName(lastName)) {
+    return NextResponse.json({ error: "Last name must contain letters only." }, { status: 400 });
+  }
   if (!validateEmail(email)) {
     return NextResponse.json({ error: "Enter a valid email address." }, { status: 400 });
   }
@@ -55,6 +81,13 @@ export async function POST(request: Request) {
         passwordHash,
         role: UserRole.ADMIN,
         status: UserStatus.ACTIVE,
+        adminProfile: {
+          create: {
+            firstName,
+            middleName,
+            lastName,
+          },
+        },
       },
     });
 

--- a/src/app/api/admin/register-first/route.ts
+++ b/src/app/api/admin/register-first/route.ts
@@ -3,24 +3,50 @@ import { UserRole, UserStatus } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { hashPassword } from "@/lib/password";
 import { prismaErrorToResponse } from "@/lib/prisma-errors";
-import { validateEmail, validatePassword } from "@/lib/validators";
+import { validateEmail, validateLettersOnlyName, validatePassword } from "@/lib/validators";
 
 function isStylehairAdminEmail(email: string) {
   return /^[^\s@]+@stylehair\.com$/i.test(email);
 }
 
 export async function POST(request: Request) {
-  let body: { email?: string; password?: string; confirmPassword?: string };
+  let body: {
+    firstName?: string;
+    middleName?: string;
+    lastName?: string;
+    email?: string;
+    password?: string;
+    confirmPassword?: string;
+  };
   try {
-    body = (await request.json()) as { email?: string; password?: string; confirmPassword?: string };
+    body = (await request.json()) as {
+      firstName?: string;
+      middleName?: string;
+      lastName?: string;
+      email?: string;
+      password?: string;
+      confirmPassword?: string;
+    };
   } catch {
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
   }
 
+  const firstName = body.firstName?.trim() ?? "";
+  const middleName = body.middleName?.trim() ?? "";
+  const lastName = body.lastName?.trim() ?? "";
   const email = body.email?.trim().toLowerCase() ?? "";
   const password = body.password ?? "";
   const confirmPassword = body.confirmPassword ?? "";
 
+  if (!validateLettersOnlyName(firstName)) {
+    return NextResponse.json({ error: "First name must contain letters only." }, { status: 400 });
+  }
+  if (!validateLettersOnlyName(middleName)) {
+    return NextResponse.json({ error: "Middle name must contain letters only." }, { status: 400 });
+  }
+  if (!validateLettersOnlyName(lastName)) {
+    return NextResponse.json({ error: "Last name must contain letters only." }, { status: 400 });
+  }
   if (!validateEmail(email)) {
     return NextResponse.json({ error: "Enter a valid email address." }, { status: 400 });
   }
@@ -56,6 +82,13 @@ export async function POST(request: Request) {
         passwordHash,
         role: UserRole.ADMIN,
         status: UserStatus.ACTIVE,
+        adminProfile: {
+          create: {
+            firstName,
+            middleName,
+            lastName,
+          },
+        },
       },
     });
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -16,6 +16,9 @@ export async function GET(request: Request) {
         role: true,
         status: true,
         createdAt: true,
+        adminProfile: {
+          select: { firstName: true, middleName: true, lastName: true },
+        },
         customerProfile: {
           select: { firstName: true, lastName: true, phone: true },
         },

--- a/src/components/admin/admin-users-table.tsx
+++ b/src/components/admin/admin-users-table.tsx
@@ -20,8 +20,19 @@ type UserRow = {
   role: string;
   status: string;
   createdAt: string;
+  adminProfile: { firstName: string; middleName: string; lastName: string } | null;
   customerProfile: { firstName: string; lastName: string; phone: string | null } | null;
 };
+
+function displayName(user: UserRow) {
+  if (user.adminProfile) {
+    return `${user.adminProfile.firstName} ${user.adminProfile.middleName} ${user.adminProfile.lastName}`;
+  }
+  if (user.customerProfile) {
+    return `${user.customerProfile.firstName} ${user.customerProfile.lastName}`;
+  }
+  return "";
+}
 
 export function AdminUsersTable() {
   const [users, setUsers] = useState<UserRow[]>([]);
@@ -53,7 +64,7 @@ export function AdminUsersTable() {
     const s = q.trim().toLowerCase();
     if (!s) return users;
     return users.filter((u) => {
-      const name = `${u.customerProfile?.firstName ?? ""} ${u.customerProfile?.lastName ?? ""}`.toLowerCase();
+      const name = displayName(u).toLowerCase();
       return u.email.toLowerCase().includes(s) || name.includes(s);
     });
   }, [users, q]);
@@ -120,11 +131,7 @@ export function AdminUsersTable() {
                   <tr key={u.id} className="border-t border-slate-100">
                     <td className="px-4 py-3">
                       <div className="truncate font-medium text-slate-900">{u.email}</div>
-                      {u.customerProfile ? (
-                        <div className="truncate text-xs text-slate-500">
-                          {u.customerProfile.firstName} {u.customerProfile.lastName}
-                        </div>
-                      ) : null}
+                      {displayName(u) ? <div className="truncate text-xs text-slate-500">{displayName(u)}</div> : null}
                     </td>
                     <td className="px-4 py-3 capitalize">{u.role.toLowerCase()}</td>
                     <td className="px-4 py-3 capitalize">{u.status.toLowerCase()}</td>

--- a/src/components/forms/create-admin-account-form.tsx
+++ b/src/components/forms/create-admin-account-form.tsx
@@ -2,15 +2,24 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Eye, EyeOff, Lock, Mail, UserPlus } from "lucide-react";
+import { Eye, EyeOff, Lock, Mail, User, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ROUTES } from "@/lib/routes";
-import { validateEmail } from "@/lib/validators";
+import { validateEmail, validateLettersOnlyName } from "@/lib/validators";
+
+const LETTERS_ONLY_PATTERN = "[A-Za-z]+";
+
+function lettersOnly(value: string) {
+  return value.replace(/[^A-Za-z]/g, "");
+}
 
 export function CreateAdminAccountForm() {
   const router = useRouter();
+  const [firstName, setFirstName] = useState("");
+  const [middleName, setMiddleName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -22,6 +31,9 @@ export function CreateAdminAccountForm() {
   const handleSubmit = async () => {
     setSuccess(null);
     const nextErrors: Record<string, string> = {};
+    if (!validateLettersOnlyName(firstName)) nextErrors.firstName = "First name must contain letters only.";
+    if (!validateLettersOnlyName(middleName)) nextErrors.middleName = "Middle name must contain letters only.";
+    if (!validateLettersOnlyName(lastName)) nextErrors.lastName = "Last name must contain letters only.";
     if (!validateEmail(email)) nextErrors.email = "Enter a valid email.";
     if (!email.toLowerCase().endsWith("@stylehair.com")) {
       nextErrors.email = "Use an @stylehair.com address (e.g. maria@stylehair.com).";
@@ -41,6 +53,9 @@ export function CreateAdminAccountForm() {
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({
+          firstName: firstName.trim(),
+          middleName: middleName.trim(),
+          lastName: lastName.trim(),
           email: email.trim().toLowerCase(),
           password,
           confirmPassword,
@@ -52,6 +67,9 @@ export function CreateAdminAccountForm() {
         return;
       }
       setSuccess(data.message ?? "Administrator created. They can sign in now.");
+      setFirstName("");
+      setMiddleName("");
+      setLastName("");
       setEmail("");
       setPassword("");
       setConfirmPassword("");
@@ -69,6 +87,56 @@ export function CreateAdminAccountForm() {
         <div className="rounded-2xl border border-emerald-200 bg-emerald-50/90 px-4 py-3 text-sm text-emerald-900">{success}</div>
       ) : null}
       {errors.form ? <p className="text-sm text-rose-600">{errors.form}</p> : null}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <Label htmlFor="new-admin-first-name">First name</Label>
+          <div className="relative">
+            <User className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-slate-400" />
+            <Input
+              id="new-admin-first-name"
+              className="h-12 rounded-2xl border-slate-200 bg-white/80 pl-10 shadow-inner shadow-slate-200/40 backdrop-blur"
+              placeholder="Maria"
+              value={firstName}
+              onChange={(e) => setFirstName(lettersOnly(e.target.value))}
+              pattern={LETTERS_ONLY_PATTERN}
+              title="Use letters only."
+              autoComplete="given-name"
+            />
+          </div>
+          {errors.firstName ? <p className="text-xs text-rose-500">{errors.firstName}</p> : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="new-admin-middle-name">Middle name</Label>
+          <Input
+            id="new-admin-middle-name"
+            className="h-12 rounded-2xl border-slate-200 bg-white/80 shadow-inner shadow-slate-200/40 backdrop-blur"
+            placeholder="Santos"
+            value={middleName}
+            onChange={(e) => setMiddleName(lettersOnly(e.target.value))}
+            pattern={LETTERS_ONLY_PATTERN}
+            title="Use letters only."
+            autoComplete="additional-name"
+          />
+          {errors.middleName ? <p className="text-xs text-rose-500">{errors.middleName}</p> : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="new-admin-last-name">Last name</Label>
+          <Input
+            id="new-admin-last-name"
+            className="h-12 rounded-2xl border-slate-200 bg-white/80 shadow-inner shadow-slate-200/40 backdrop-blur"
+            placeholder="Reyes"
+            value={lastName}
+            onChange={(e) => setLastName(lettersOnly(e.target.value))}
+            pattern={LETTERS_ONLY_PATTERN}
+            title="Use letters only."
+            autoComplete="family-name"
+          />
+          {errors.lastName ? <p className="text-xs text-rose-500">{errors.lastName}</p> : null}
+        </div>
+      </div>
 
       <div className="space-y-2">
         <Label htmlFor="new-admin-email">Admin email</Label>

--- a/src/components/forms/first-admin-setup-form.tsx
+++ b/src/components/forms/first-admin-setup-form.tsx
@@ -2,17 +2,26 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Eye, EyeOff, Lock, Mail } from "lucide-react";
+import { Eye, EyeOff, Lock, Mail, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ROUTES } from "@/lib/routes";
-import { validateEmail } from "@/lib/validators";
+import { validateEmail, validateLettersOnlyName } from "@/lib/validators";
+
+const LETTERS_ONLY_PATTERN = "[A-Za-z]+";
+
+function lettersOnly(value: string) {
+  return value.replace(/[^A-Za-z]/g, "");
+}
 
 export function FirstAdminSetupForm() {
   const router = useRouter();
   const [checking, setChecking] = useState(true);
   const [allowed, setAllowed] = useState(false);
+  const [firstName, setFirstName] = useState("");
+  const [middleName, setMiddleName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -48,6 +57,9 @@ export function FirstAdminSetupForm() {
 
   const handleSubmit = async () => {
     const nextErrors: Record<string, string> = {};
+    if (!validateLettersOnlyName(firstName)) nextErrors.firstName = "First name must contain letters only.";
+    if (!validateLettersOnlyName(middleName)) nextErrors.middleName = "Middle name must contain letters only.";
+    if (!validateLettersOnlyName(lastName)) nextErrors.lastName = "Last name must contain letters only.";
     if (!validateEmail(email)) nextErrors.email = "Enter a valid email.";
     if (!email.toLowerCase().endsWith("@stylehair.com")) {
       nextErrors.email = "Use an @stylehair.com address (e.g. maria@stylehair.com).";
@@ -66,6 +78,9 @@ export function FirstAdminSetupForm() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          firstName: firstName.trim(),
+          middleName: middleName.trim(),
+          lastName: lastName.trim(),
           email: email.trim().toLowerCase(),
           password,
           confirmPassword,
@@ -114,6 +129,56 @@ export function FirstAdminSetupForm() {
 
       {allowed ? (
         <>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="admin-setup-first-name">First name</Label>
+              <div className="relative">
+                <User className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-slate-400" />
+                <Input
+                  id="admin-setup-first-name"
+                  className="h-12 rounded-2xl pl-10"
+                  placeholder="Maria"
+                  value={firstName}
+                  onChange={(e) => setFirstName(lettersOnly(e.target.value))}
+                  pattern={LETTERS_ONLY_PATTERN}
+                  title="Use letters only."
+                  autoComplete="given-name"
+                />
+              </div>
+              {errors.firstName ? <p className="text-xs text-rose-500">{errors.firstName}</p> : null}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="admin-setup-middle-name">Middle name</Label>
+              <Input
+                id="admin-setup-middle-name"
+                className="h-12 rounded-2xl"
+                placeholder="Santos"
+                value={middleName}
+                onChange={(e) => setMiddleName(lettersOnly(e.target.value))}
+                pattern={LETTERS_ONLY_PATTERN}
+                title="Use letters only."
+                autoComplete="additional-name"
+              />
+              {errors.middleName ? <p className="text-xs text-rose-500">{errors.middleName}</p> : null}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="admin-setup-last-name">Last name</Label>
+              <Input
+                id="admin-setup-last-name"
+                className="h-12 rounded-2xl"
+                placeholder="Reyes"
+                value={lastName}
+                onChange={(e) => setLastName(lettersOnly(e.target.value))}
+                pattern={LETTERS_ONLY_PATTERN}
+                title="Use letters only."
+                autoComplete="family-name"
+              />
+              {errors.lastName ? <p className="text-xs text-rose-500">{errors.lastName}</p> : null}
+            </div>
+          </div>
+
           <div className="space-y-2">
             <Label htmlFor="admin-setup-email">Admin email</Label>
             <div className="relative">

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -6,6 +6,10 @@ export function validatePassword(password: string) {
   return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(password);
 }
 
+export function validateLettersOnlyName(name: string) {
+  return /^[A-Za-z]+$/.test(name);
+}
+
 export function validatePhone(phone: string) {
   if (!phone) return true;
   return /^[\d+()\-\s]{7,20}$/.test(phone);


### PR DESCRIPTION
## Summary
- Added required admin name fields when creating admin accounts.
- Needed so admin accounts store complete name details, not just email/password, with validation against numbers and special characters.

## Changes
- Added AdminProfile model/table with firstName, middleName, and lastName.
- Updated admin creation API to validate and save admin profile names.
- Updated first-admin setup API to collect the same name fields.
- Added validateLettersOnlyName() shared validator.
- Updated admin creation forms with separate first, middle, and last name inputs.
- Added client-side filtering so name inputs accept letters only.
- Added server-side validation to reject invalid name payloads.
- Updated admin users API/table to fetch, search, and display admin profile names.
- Ran prisma generate and prisma db push to sync Prisma Client and database.

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
