### PR TITLE
3B-G10-W009.Creation of Component Props Interface

### DIFF
--- a/src/components/admin/admin-growth-charts.tsx
+++ b/src/components/admin/admin-growth-charts.tsx
@@ -120,7 +120,11 @@ function ChartTooltip({
   );
 }
 
-export function AdminGrowthCharts({ data }: { data: GrowthChartRow[] }) {
+interface AdminGrowthChartsProps {
+  data: GrowthChartRow[];
+}
+
+export function AdminGrowthCharts({ data }: Readonly<AdminGrowthChartsProps>) {
   const satisfactionSeries = buildSatisfactionSeries(data);
   const satSummary = satisfactionPeriodSummary(satisfactionSeries);
 

--- a/src/components/admin/admin-layout-chrome.tsx
+++ b/src/components/admin/admin-layout-chrome.tsx
@@ -8,6 +8,10 @@ import { AdminSidebarNav } from "@/components/admin/admin-sidebar-nav";
 import { AdminMobileNav } from "@/components/admin/admin-mobile-nav";
 import { ROUTES } from "@/lib/routes";
 
+interface AdminLayoutChromeProps {
+  children: ReactNode;
+}
+
 const adminLinks = [
   { href: ROUTES.adminDashboard, label: "Overview", icon: Home },
   { href: ROUTES.adminUsers, label: "Users", icon: Users },
@@ -16,7 +20,7 @@ const adminLinks = [
   { href: ROUTES.adminSettings, label: "Settings", icon: Settings },
 ];
 
-export function AdminLayoutChrome({ children }: { children: ReactNode }) {
+export function AdminLayoutChrome({ children }: Readonly<AdminLayoutChromeProps>) {
   return (
     <div className="min-h-screen bg-[linear-gradient(165deg,#f8fafc_0%,#eef2ff_45%,#faf5ff_100%)] md:grid md:grid-cols-[272px_1fr]">
       <aside className="relative hidden overflow-hidden border-r border-white/50 bg-gradient-to-b from-slate-900 via-indigo-950 to-slate-900 px-5 py-6 text-white shadow-xl shadow-indigo-950/20 md:block">

--- a/src/components/forms/admin-login-form.tsx
+++ b/src/components/forms/admin-login-form.tsx
@@ -9,7 +9,11 @@ import { Label } from "@/components/ui/label";
 import { validateEmail } from "@/lib/validators";
 import { ROUTES } from "@/lib/routes";
 
-export function AdminLoginForm({ nextPath }: { nextPath?: string }) {
+interface AdminLoginFormProps {
+  nextPath?: string;
+}
+
+export function AdminLoginForm({ nextPath }: Readonly<AdminLoginFormProps>) {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [form, setForm] = useState({ email: "", password: "" });

--- a/src/components/forms/customer-login-form.tsx
+++ b/src/components/forms/customer-login-form.tsx
@@ -10,7 +10,11 @@ import { Label } from "@/components/ui/label";
 import { ROUTES } from "@/lib/routes";
 import { validateEmail } from "@/lib/validators";
 
-export function CustomerLoginForm({ nextPath }: { nextPath?: string }) {
+interface CustomerLoginFormProps {
+  nextPath?: string;
+}
+
+export function CustomerLoginForm({ nextPath }: Readonly<CustomerLoginFormProps>) {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [form, setForm] = useState({ email: "", password: "" });

--- a/src/components/layout/brand.tsx
+++ b/src/components/layout/brand.tsx
@@ -1,9 +1,13 @@
 import { Scissors } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+interface BrandProps {
+  inverted?: boolean;
+}
+
 const BRAND_MARK = `StyleH${"\u1D00"}${"\u026A"}R`;
 
-export function Brand({ inverted }: { inverted?: boolean }) {
+export function Brand({ inverted }: Readonly<BrandProps>) {
   return (
     <div className="flex items-center gap-3">
       <div

--- a/src/components/shared/app-shell.tsx
+++ b/src/components/shared/app-shell.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 
-export function AppShell({ children }: { children: ReactNode }) {
+interface AppShellProps {
+  children: ReactNode;
+}
+
+export function AppShell({ children }: Readonly<AppShellProps>) {
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-slate-50 text-slate-900">
       <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(ellipse_120%_80%_at_50%_-40%,rgba(99,102,241,0.12),transparent),radial-gradient(circle_at_100%_0%,rgba(244,114,182,0.08),transparent)]" />

--- a/src/components/shared/section-header.tsx
+++ b/src/components/shared/section-header.tsx
@@ -1,4 +1,9 @@
-export function SectionHeader({ title, description }: { title: string; description: string }) {
+interface SectionHeaderProps {
+  title: string;
+  description: string;
+}
+
+export function SectionHeader({ title, description }: Readonly<SectionHeaderProps>) {
   return (
     <div className="space-y-2 border-b border-slate-200/80 pb-6">
       <h2 className="text-2xl font-semibold tracking-tight text-slate-900">{title}</h2>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,14 +1,29 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-export function Alert({ className, children }: { className?: string; children: ReactNode }) {
+interface AlertProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface AlertTitleProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface AlertDescriptionProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export function Alert({ className, children }: Readonly<AlertProps>) {
   return <div className={cn("rounded-2xl border border-slate-200 bg-slate-50 p-4", className)}>{children}</div>;
 }
 
-export function AlertTitle({ className, children }: { className?: string; children: ReactNode }) {
+export function AlertTitle({ className, children }: Readonly<AlertTitleProps>) {
   return <div className={cn("text-sm font-semibold text-slate-900", className)}>{children}</div>;
 }
 
-export function AlertDescription({ className, children }: { className?: string; children: ReactNode }) {
+export function AlertDescription({ className, children }: Readonly<AlertDescriptionProps>) {
   return <div className={cn("mt-1 text-sm leading-6 text-slate-500", className)}>{children}</div>;
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -15,6 +15,42 @@ type DialogContextValue = {
   onOpenChange: (open: boolean) => void;
 };
 
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+interface DialogTriggerProps {
+  asChild?: boolean;
+  children: ReactNode;
+}
+
+interface DialogContentProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface DialogHeaderProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface DialogTitleProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface DialogDescriptionProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface DialogFooterProps {
+  className?: string;
+  children: ReactNode;
+}
+
 const DialogContext = createContext<DialogContextValue | null>(null);
 
 function useDialogContext() {
@@ -29,21 +65,14 @@ export function Dialog({
   open,
   onOpenChange,
   children,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  children: ReactNode;
-}) {
+}: Readonly<DialogProps>) {
   return <DialogContext.Provider value={{ open, onOpenChange }}>{children}</DialogContext.Provider>;
 }
 
 export function DialogTrigger({
   asChild,
   children,
-}: {
-  asChild?: boolean;
-  children: ReactNode;
-}) {
+}: Readonly<DialogTriggerProps>) {
   const { onOpenChange } = useDialogContext();
 
   if (asChild && isValidElement(children)) {
@@ -66,10 +95,7 @@ export function DialogTrigger({
 export function DialogContent({
   className,
   children,
-}: {
-  className?: string;
-  children: ReactNode;
-}) {
+}: Readonly<DialogContentProps>) {
   const { open, onOpenChange } = useDialogContext();
 
   if (!open) {
@@ -86,18 +112,18 @@ export function DialogContent({
   );
 }
 
-export function DialogHeader({ className, children }: { className?: string; children: ReactNode }) {
+export function DialogHeader({ className, children }: Readonly<DialogHeaderProps>) {
   return <div className={cn("space-y-2", className)}>{children}</div>;
 }
 
-export function DialogTitle({ className, children }: { className?: string; children: ReactNode }) {
+export function DialogTitle({ className, children }: Readonly<DialogTitleProps>) {
   return <h3 className={cn("text-xl font-semibold text-slate-950", className)}>{children}</h3>;
 }
 
-export function DialogDescription({ className, children }: { className?: string; children: ReactNode }) {
+export function DialogDescription({ className, children }: Readonly<DialogDescriptionProps>) {
   return <p className={cn("text-sm leading-6 text-slate-500", className)}>{children}</p>;
 }
 
-export function DialogFooter({ className, children }: { className?: string; children: ReactNode }) {
+export function DialogFooter({ className, children }: Readonly<DialogFooterProps>) {
   return <div className={cn("mt-5 flex justify-end", className)}>{children}</div>;
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,6 +17,30 @@ type SelectContextValue = {
   onValueChange: (value: string) => void;
 };
 
+interface SelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  children: ReactNode;
+}
+
+interface SelectTriggerProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface SelectValueProps {
+  placeholder?: string;
+}
+
+interface SelectContentProps {
+  children: ReactNode;
+}
+
+interface SelectItemProps {
+  value: string;
+  children: ReactNode;
+}
+
 const SelectContext = createContext<SelectContextValue | null>(null);
 
 function useSelectContext() {
@@ -31,16 +55,12 @@ export function Select({
   value,
   onValueChange,
   children,
-}: {
-  value: string;
-  onValueChange: (value: string) => void;
-  children: ReactNode;
-}) {
+}: Readonly<SelectProps>) {
   const context = useMemo(() => ({ value, onValueChange }), [value, onValueChange]);
   return <SelectContext.Provider value={context}>{children}</SelectContext.Provider>;
 }
 
-export function SelectTrigger({ className, children }: { className?: string; children: ReactNode }) {
+export function SelectTrigger({ className, children }: Readonly<SelectTriggerProps>) {
   const { value, onValueChange } = useSelectContext();
   const content = Children.toArray(children);
   const triggerChild = content.find((child) => isValidElement(child) && child.type === SelectValue) as
@@ -73,14 +93,14 @@ export function SelectTrigger({ className, children }: { className?: string; chi
   );
 }
 
-export function SelectValue({ placeholder }: { placeholder?: string }) {
+export function SelectValue({ placeholder }: Readonly<SelectValueProps>) {
   return <>{placeholder}</>;
 }
 
-export function SelectContent({ children }: { children: ReactNode }) {
+export function SelectContent({ children }: Readonly<SelectContentProps>) {
   return <>{children}</>;
 }
 
-export function SelectItem({ value, children }: { value: string; children: ReactNode }) {
+export function SelectItem({ value, children }: Readonly<SelectItemProps>) {
   return <option value={value}>{children}</option>;
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -18,6 +18,29 @@ type TabsContextValue = {
   setValue: (value: string) => void;
 };
 
+interface TabsProps {
+  defaultValue: string;
+  className?: string;
+  children: ReactNode;
+}
+
+interface TabsListProps {
+  className?: string;
+  children: ReactNode;
+}
+
+interface TabsTriggerProps {
+  value: string;
+  className?: string;
+  children: ReactNode;
+}
+
+interface TabsContentProps {
+  value: string;
+  className?: string;
+  children: ReactNode;
+}
+
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 function useTabsContext() {
@@ -32,11 +55,7 @@ export function Tabs({
   defaultValue,
   className,
   children,
-}: {
-  defaultValue: string;
-  className?: string;
-  children: ReactNode;
-}) {
+}: Readonly<TabsProps>) {
   const [value, setValue] = useState(defaultValue);
   const context = useMemo(() => ({ value, setValue }), [value]);
 
@@ -47,7 +66,7 @@ export function Tabs({
   );
 }
 
-export function TabsList({ className, children }: { className?: string; children: ReactNode }) {
+export function TabsList({ className, children }: Readonly<TabsListProps>) {
   return <div className={cn("inline-flex gap-2", className)}>{children}</div>;
 }
 
@@ -55,11 +74,7 @@ export function TabsTrigger({
   value,
   className,
   children,
-}: {
-  value: string;
-  className?: string;
-  children: ReactNode;
-}) {
+}: Readonly<TabsTriggerProps>) {
   const { value: active, setValue } = useTabsContext();
 
   return (
@@ -81,11 +96,7 @@ export function TabsContent({
   value,
   className,
   children,
-}: {
-  value: string;
-  className?: string;
-  children: ReactNode;
-}) {
+}: Readonly<TabsContentProps>) {
   const { value: active } = useTabsContext();
 
   if (active !== value) {


### PR DESCRIPTION
## Summary
- Changed component props typing from inline object annotations to named interfaces.
- Needed to standardize prop declarations and reduce function signature clutter while using [Readonly] for immutability.

## Changes
- Added props interfaces for affected components.
- Updated component signatures to use

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
